### PR TITLE
Replaced every PII naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axon Data Protection Maven Plugin
 
-Axon Data Protection Maven Plugin is a Maven Plugin responsible to generate the config file to be used on the Axon Server Plugin Data Protection module. The config is generated based on Annotated Classes (using the Axon Data Protection Config API Annotations) and the output is a Json file, which is the input for the Axon Server Data Protection Plugin.
+Axon Data Protection Maven Plugin is a Maven Plugin responsible to generate the config file to be used on the Axon Server Plugin Data Protection module. The config is generated based on Annotated Classes (using the Axon Data Protection Config API Annotations) and the output is a Json file, which is one of the inputs for the Axon Server Data Protection Plugin.
 
 For having the properly Annotations scanned, the `axon-dataprotection-config-api` is needed, and you can configure it like so:
 ```xml
@@ -13,7 +13,9 @@ For having the properly Annotations scanned, the `axon-dataprotection-config-api
 ```
 
 This Plugin is hooked into the `compile` phase of the Maven Lifecycle and has a goal named `generate`.
-The mandatory configuration is a `packages` list where you can specify all `package`s where the plugin should scan for Annotated Classes.
+The mandatory configuration is a `packages` list where you can specify all `package`s where the plugin should scan for Annotated Classes. The optional configuration is the `outputConfig` where you can specify the directory you want the output json to be created. By default, it creates a file named `axon-data-protection-config.json` on your `target` folder.
+
+> It has proven to be a good practice to make this json part of your git repository, so you can follow the evolving of your configuration as well as be notified (by git) when it changed to not forget to change it on the server.
 
 Basically, this is an example of what you need on your project:
 
@@ -25,11 +27,14 @@ Basically, this is an example of what you need on your project:
         <artifactId>axon-dataprotection-maven-plugin</artifactId>
         <version>1.0-SNAPSHOT</version>
         <configuration>
+            <!-- required -->
             <packages>
                 <package>io.axoniq.package1</package>
                 <package>io.axoniq.package2</package>
                 <package>io.axoniq.package3</package>
             </packages>
+            <!-- optional -->
+            <outputConfig>output.json</outputConfig>
         </configuration>
         <executions>
             <execution>

--- a/src/main/java/io/axoniq/plugin/data/protection/generator/AxonDataProtectionMojo.java
+++ b/src/main/java/io/axoniq/plugin/data/protection/generator/AxonDataProtectionMojo.java
@@ -53,8 +53,8 @@ public class AxonDataProtectionMojo extends AbstractMojo {
     private PluginDescriptor descriptor;
 
     /**
-     * This property specify in which packages the plugin should look for the PII Annotation to start generating the
-     * metamodel.
+     * This property specify in which packages the plugin should look for the {@link
+     * io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder} Annotation to start generating the metamodel.
      */
     @Parameter(property = "packages", required = true)
     private List<String> packages;

--- a/src/main/java/io/axoniq/plugin/data/protection/generator/errors/NoSensitiveDataHolderAnnotationException.java
+++ b/src/main/java/io/axoniq/plugin/data/protection/generator/errors/NoSensitiveDataHolderAnnotationException.java
@@ -17,16 +17,16 @@
 package io.axoniq.plugin.data.protection.generator.errors;
 
 /**
- * Exception to indicate that a given Class do not contain a {@link io.axoniq.plugin.data.protection.annotation.PII}
+ * Exception to indicate that a given Class do not contain a {@link io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder}
  * annotation on it.
  */
-public class NoPIIAnnotationException extends RuntimeException {
+public class NoSensitiveDataHolderAnnotationException extends RuntimeException {
 
-    public NoPIIAnnotationException(String message) {
+    public NoSensitiveDataHolderAnnotationException(String message) {
         super(message);
     }
 
-    public NoPIIAnnotationException(Class<?> clazz) {
-        super("No PII annotated class found in [" + clazz + "]");
+    public NoSensitiveDataHolderAnnotationException(Class<?> clazz) {
+        super("No SensitiveDataHolder annotated class found in [" + clazz + "]");
     }
 }

--- a/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorArrayTypesTest.java
+++ b/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorArrayTypesTest.java
@@ -16,8 +16,8 @@
 
 package io.axoniq.plugin.data.protection.generator;
 
-import io.axoniq.plugin.data.protection.annotation.PII;
 import io.axoniq.plugin.data.protection.annotation.SensitiveData;
+import io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder;
 import io.axoniq.plugin.data.protection.annotation.SubjectId;
 import io.axoniq.plugin.data.protection.config.DataProtectionConfig;
 import io.axoniq.plugin.data.protection.config.SensitiveDataConfig;
@@ -57,7 +57,7 @@ class MetamodelGeneratorArrayTypesTest {
         Assertions.assertEquals(expected, result);
     }
 
-    @PII
+    @SensitiveDataHolder
     static class ArrayTest {
 
         @SubjectId
@@ -67,7 +67,7 @@ class MetamodelGeneratorArrayTypesTest {
         String[] sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class ComplexArrayTest {
 
         @SubjectId

--- a/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorBoxedTypesTest.java
+++ b/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorBoxedTypesTest.java
@@ -16,8 +16,8 @@
 
 package io.axoniq.plugin.data.protection.generator;
 
-import io.axoniq.plugin.data.protection.annotation.PII;
 import io.axoniq.plugin.data.protection.annotation.SensitiveData;
+import io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder;
 import io.axoniq.plugin.data.protection.annotation.SubjectId;
 import io.axoniq.plugin.data.protection.config.DataProtectionConfig;
 import io.axoniq.plugin.data.protection.config.SensitiveDataConfig;
@@ -145,7 +145,7 @@ class MetamodelGeneratorBoxedTypesTest {
         Assertions.assertEquals(expected, result);
     }
 
-    @PII
+    @SensitiveDataHolder
     static class IntegerTest {
 
         @SubjectId
@@ -155,7 +155,7 @@ class MetamodelGeneratorBoxedTypesTest {
         Integer sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class StringTest {
 
         @SubjectId
@@ -165,7 +165,7 @@ class MetamodelGeneratorBoxedTypesTest {
         String sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class FloatTest {
 
         @SubjectId
@@ -175,7 +175,7 @@ class MetamodelGeneratorBoxedTypesTest {
         Float sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class BooleanTest {
 
         @SubjectId
@@ -185,7 +185,7 @@ class MetamodelGeneratorBoxedTypesTest {
         Boolean sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class LongTest {
 
         @SubjectId
@@ -195,7 +195,7 @@ class MetamodelGeneratorBoxedTypesTest {
         Long sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class ShortTest {
 
         @SubjectId
@@ -205,7 +205,7 @@ class MetamodelGeneratorBoxedTypesTest {
         Short sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class DoubleTest {
 
         @SubjectId
@@ -215,7 +215,7 @@ class MetamodelGeneratorBoxedTypesTest {
         Double sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class CharacterTest {
 
         @SubjectId
@@ -225,7 +225,7 @@ class MetamodelGeneratorBoxedTypesTest {
         Character sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class ByteTest {
 
         @SubjectId

--- a/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorCollectionTypesTest.java
+++ b/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorCollectionTypesTest.java
@@ -16,8 +16,8 @@
 
 package io.axoniq.plugin.data.protection.generator;
 
-import io.axoniq.plugin.data.protection.annotation.PII;
 import io.axoniq.plugin.data.protection.annotation.SensitiveData;
+import io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder;
 import io.axoniq.plugin.data.protection.annotation.SubjectId;
 import io.axoniq.plugin.data.protection.config.DataProtectionConfig;
 import io.axoniq.plugin.data.protection.config.SensitiveDataConfig;
@@ -71,7 +71,7 @@ class MetamodelGeneratorCollectionTypesTest {
         Assertions.assertEquals(expected, result);
     }
 
-    @PII
+    @SensitiveDataHolder
     static class ListTest {
 
         @SubjectId
@@ -81,7 +81,7 @@ class MetamodelGeneratorCollectionTypesTest {
         List<String> sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class SetTest {
 
         @SubjectId
@@ -91,7 +91,7 @@ class MetamodelGeneratorCollectionTypesTest {
         Set<String> sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class CollectionTest {
 
         @SubjectId

--- a/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorComplexTypesTest.java
+++ b/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorComplexTypesTest.java
@@ -16,8 +16,8 @@
 
 package io.axoniq.plugin.data.protection.generator;
 
-import io.axoniq.plugin.data.protection.annotation.PII;
 import io.axoniq.plugin.data.protection.annotation.SensitiveData;
+import io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder;
 import io.axoniq.plugin.data.protection.annotation.SubjectId;
 import io.axoniq.plugin.data.protection.config.DataProtectionConfig;
 import io.axoniq.plugin.data.protection.config.SensitiveDataConfig;
@@ -88,7 +88,7 @@ class MetamodelGeneratorComplexTypesTest {
         Assertions.assertEquals(expected, result);
     }
 
-    @PII
+    @SensitiveDataHolder
     static class ComplexTest {
 
         @SubjectId
@@ -97,7 +97,7 @@ class MetamodelGeneratorComplexTypesTest {
         ComplexType sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class ComplexListTest {
 
         @SubjectId
@@ -106,7 +106,7 @@ class MetamodelGeneratorComplexTypesTest {
         List<ComplexType> sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class ComplexSetTest {
 
         @SubjectId
@@ -115,7 +115,7 @@ class MetamodelGeneratorComplexTypesTest {
         Set<ComplexType> sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class ComplexCollectionTest {
 
         @SubjectId

--- a/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorDateTimeTypesTest.java
+++ b/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorDateTimeTypesTest.java
@@ -16,8 +16,8 @@
 
 package io.axoniq.plugin.data.protection.generator;
 
-import io.axoniq.plugin.data.protection.annotation.PII;
 import io.axoniq.plugin.data.protection.annotation.SensitiveData;
+import io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder;
 import io.axoniq.plugin.data.protection.annotation.SubjectId;
 import io.axoniq.plugin.data.protection.config.DataProtectionConfig;
 import io.axoniq.plugin.data.protection.config.SensitiveDataConfig;
@@ -155,7 +155,7 @@ class MetamodelGeneratorDateTimeTypesTest {
         Assertions.assertEquals(expected, result);
     }
 
-    @PII
+    @SensitiveDataHolder
     static class DateTest {
 
         @SubjectId
@@ -165,7 +165,7 @@ class MetamodelGeneratorDateTimeTypesTest {
         Date sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class LocalDateTest {
 
         @SubjectId
@@ -175,7 +175,7 @@ class MetamodelGeneratorDateTimeTypesTest {
         LocalDate sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class LocalTimeTest {
 
         @SubjectId
@@ -185,7 +185,7 @@ class MetamodelGeneratorDateTimeTypesTest {
         LocalTime sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class LocalDateTimeTest {
 
         @SubjectId
@@ -195,7 +195,7 @@ class MetamodelGeneratorDateTimeTypesTest {
         LocalDateTime sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class OffsetDateTimeTest {
 
         @SubjectId
@@ -205,7 +205,7 @@ class MetamodelGeneratorDateTimeTypesTest {
         OffsetDateTime sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class ZonedDateTimeTest {
 
         @SubjectId
@@ -215,7 +215,7 @@ class MetamodelGeneratorDateTimeTypesTest {
         ZonedDateTime sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class InstantTest {
 
         @SubjectId
@@ -225,7 +225,7 @@ class MetamodelGeneratorDateTimeTypesTest {
         Instant sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class PeriodTest {
 
         @SubjectId
@@ -235,7 +235,7 @@ class MetamodelGeneratorDateTimeTypesTest {
         Period sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class DurationTest {
 
         @SubjectId

--- a/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorExtraTypesTest.java
+++ b/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorExtraTypesTest.java
@@ -16,8 +16,8 @@
 
 package io.axoniq.plugin.data.protection.generator;
 
-import io.axoniq.plugin.data.protection.annotation.PII;
 import io.axoniq.plugin.data.protection.annotation.SensitiveData;
+import io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder;
 import io.axoniq.plugin.data.protection.annotation.SubjectId;
 import io.axoniq.plugin.data.protection.config.DataProtectionConfig;
 import io.axoniq.plugin.data.protection.config.SensitiveDataConfig;
@@ -43,7 +43,7 @@ class MetamodelGeneratorExtraTypesTest {
         Assertions.assertEquals(expected, result);
     }
 
-    @PII
+    @SensitiveDataHolder
     static class UUIDTest {
 
         @SubjectId

--- a/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorMapTypesTest.java
+++ b/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorMapTypesTest.java
@@ -16,8 +16,8 @@
 
 package io.axoniq.plugin.data.protection.generator;
 
-import io.axoniq.plugin.data.protection.annotation.PII;
 import io.axoniq.plugin.data.protection.annotation.SensitiveData;
+import io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder;
 import io.axoniq.plugin.data.protection.annotation.SubjectId;
 import io.axoniq.plugin.data.protection.config.DataProtectionConfig;
 import io.axoniq.plugin.data.protection.config.SensitiveDataConfig;
@@ -58,7 +58,7 @@ class MetamodelGeneratorMapTypesTest {
         Assertions.assertEquals(expected, result);
     }
 
-    @PII
+    @SensitiveDataHolder
     static class MapTest {
 
         @SubjectId
@@ -68,7 +68,7 @@ class MetamodelGeneratorMapTypesTest {
         Map<String, String> sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class ComplexMapTest {
 
         @SubjectId

--- a/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorMathTypesTest.java
+++ b/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorMathTypesTest.java
@@ -16,8 +16,8 @@
 
 package io.axoniq.plugin.data.protection.generator;
 
-import io.axoniq.plugin.data.protection.annotation.PII;
 import io.axoniq.plugin.data.protection.annotation.SensitiveData;
+import io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder;
 import io.axoniq.plugin.data.protection.annotation.SubjectId;
 import io.axoniq.plugin.data.protection.config.DataProtectionConfig;
 import io.axoniq.plugin.data.protection.config.SensitiveDataConfig;
@@ -58,7 +58,7 @@ class MetamodelGeneratorMathTypesTest {
     }
 
 
-    @PII
+    @SensitiveDataHolder
     static class BigDecimalTest {
 
         @SubjectId
@@ -68,7 +68,7 @@ class MetamodelGeneratorMathTypesTest {
         BigDecimal sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class BigIntegerTest {
 
         @SubjectId

--- a/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorPrimitiveTypesTest.java
+++ b/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorPrimitiveTypesTest.java
@@ -16,8 +16,8 @@
 
 package io.axoniq.plugin.data.protection.generator;
 
-import io.axoniq.plugin.data.protection.annotation.PII;
 import io.axoniq.plugin.data.protection.annotation.SensitiveData;
+import io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder;
 import io.axoniq.plugin.data.protection.annotation.SubjectId;
 import io.axoniq.plugin.data.protection.config.DataProtectionConfig;
 import io.axoniq.plugin.data.protection.config.SensitiveDataConfig;
@@ -132,7 +132,7 @@ class MetamodelGeneratorPrimitiveTypesTest {
         Assertions.assertEquals(expected, result);
     }
 
-    @PII
+    @SensitiveDataHolder
     static class IntTest {
 
         @SubjectId
@@ -142,7 +142,7 @@ class MetamodelGeneratorPrimitiveTypesTest {
         int sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class FloatTest {
 
         @SubjectId
@@ -152,7 +152,7 @@ class MetamodelGeneratorPrimitiveTypesTest {
         float sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class BooleanTest {
 
         @SubjectId
@@ -162,7 +162,7 @@ class MetamodelGeneratorPrimitiveTypesTest {
         boolean sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class LongTest {
 
         @SubjectId
@@ -172,7 +172,7 @@ class MetamodelGeneratorPrimitiveTypesTest {
         long sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class ShortTest {
 
         @SubjectId
@@ -182,7 +182,7 @@ class MetamodelGeneratorPrimitiveTypesTest {
         short sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class DoubleTest {
 
         @SubjectId
@@ -192,7 +192,7 @@ class MetamodelGeneratorPrimitiveTypesTest {
         double sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class CharacterTest {
 
         @SubjectId
@@ -202,7 +202,7 @@ class MetamodelGeneratorPrimitiveTypesTest {
         char sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class ByteTest {
 
         @SubjectId

--- a/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorTest.java
+++ b/src/test/java/io/axoniq/plugin/data/protection/generator/MetamodelGeneratorTest.java
@@ -16,10 +16,10 @@
 
 package io.axoniq.plugin.data.protection.generator;
 
-import io.axoniq.plugin.data.protection.annotation.PII;
 import io.axoniq.plugin.data.protection.annotation.SensitiveData;
+import io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder;
 import io.axoniq.plugin.data.protection.annotation.SubjectId;
-import io.axoniq.plugin.data.protection.generator.errors.NoPIIAnnotationException;
+import io.axoniq.plugin.data.protection.generator.errors.NoSensitiveDataHolderAnnotationException;
 import io.axoniq.plugin.data.protection.generator.errors.NoSubjectIdException;
 import org.junit.jupiter.api.*;
 
@@ -28,9 +28,9 @@ public class MetamodelGeneratorTest {
     MetamodelGenerator metamodelGenerator = new MetamodelGenerator();
 
     @Test
-    void noPIIClass() {
-        Assertions.assertThrows(NoPIIAnnotationException.class,
-                                () -> metamodelGenerator.generateMetamodel(NoPIIClass.class));
+    void noSensitiveDataHolderClass() {
+        Assertions.assertThrows(NoSensitiveDataHolderAnnotationException.class,
+                                () -> metamodelGenerator.generateMetamodel(NoSensitiveDataHolderClass.class));
     }
 
     @Test
@@ -39,7 +39,7 @@ public class MetamodelGeneratorTest {
                                 () -> metamodelGenerator.generateMetamodel(NoSubjectIdClass.class));
     }
 
-    static class NoPIIClass {
+    static class NoSensitiveDataHolderClass {
 
         @SubjectId
         String subjectId;
@@ -47,7 +47,7 @@ public class MetamodelGeneratorTest {
         String sensitiveData;
     }
 
-    @PII
+    @SensitiveDataHolder
     static class NoSubjectIdClass {
 
         String subjectId;

--- a/src/test/java/io/axoniq/plugin/data/protection/testclasses/DeepPathJavaEvent.java
+++ b/src/test/java/io/axoniq/plugin/data/protection/testclasses/DeepPathJavaEvent.java
@@ -1,10 +1,10 @@
 package io.axoniq.plugin.data.protection.testclasses;
 
-import io.axoniq.plugin.data.protection.annotation.PII;
 import io.axoniq.plugin.data.protection.annotation.SensitiveData;
+import io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder;
 import io.axoniq.plugin.data.protection.annotation.SubjectId;
 
-@PII
+@SensitiveDataHolder
 public class DeepPathJavaEvent extends CEvent implements JavaInterface {
 
     @SubjectId

--- a/src/test/java/io/axoniq/plugin/data/protection/testclasses/ShallowJavaEvent.java
+++ b/src/test/java/io/axoniq/plugin/data/protection/testclasses/ShallowJavaEvent.java
@@ -1,9 +1,9 @@
 package io.axoniq.plugin.data.protection.testclasses;
 
-import io.axoniq.plugin.data.protection.annotation.PII;
 import io.axoniq.plugin.data.protection.annotation.SensitiveData;
+import io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder;
 
-@PII
+@SensitiveDataHolder
 public class ShallowJavaEvent extends BaseEvent {
 
     @SensitiveData(replacementValue = "")

--- a/src/test/java/io/axoniq/plugin/data/protection/testclasses/testObjects.kt
+++ b/src/test/java/io/axoniq/plugin/data/protection/testclasses/testObjects.kt
@@ -1,7 +1,7 @@
 package io.axoniq.plugin.data.protection.testclasses
 
-import io.axoniq.plugin.data.protection.annotation.PII
 import io.axoniq.plugin.data.protection.annotation.SensitiveData
+import io.axoniq.plugin.data.protection.annotation.SensitiveDataHolder
 import io.axoniq.plugin.data.protection.annotation.SubjectId
 
 open class BaseEvent(
@@ -17,14 +17,14 @@ open class CEvent(
     aField: String?
 ) : BEvent(bField, aField)
 
-@PII
+@SensitiveDataHolder
 data class ShallowInheritanceEvent(
     override val id: String,
     @SensitiveData(replacementValue = "") val value: String,
     override val auditId: String = ""
 ) : BaseEvent(id, auditId)
 
-@PII
+@SensitiveDataHolder
 data class DeepInheritanceEvent(
     @SubjectId val id: String,
     @SensitiveData(replacementValue = "") val value: String,
@@ -33,7 +33,7 @@ data class DeepInheritanceEvent(
     override val aField: String?
 ) : CEvent(cField, bField, aField)
 
-@PII
+@SensitiveDataHolder
 data class SimpleFlatEvent(
     @SubjectId val id: String,
     @SensitiveData(replacementValue = "") val value: String,


### PR DESCRIPTION
Replaced every `PII` naming to the new `SensitiveDataHolder` annotation.
Also added an example for the `outputConfig` configuration.

Closes https://github.com/AxonIQ/axon-dataprotection-maven-plugin/issues/25.

---

This should be seen as a last step to make this repo open source and to publish it to maven central.